### PR TITLE
REACT-934: update volley version for RN 64 to 66 update

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ dependencies {
     implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
     implementation 'me.leolin:ShortcutBadger:1.1.17@aar'
     implementation "com.android.support:support-core-utils:27.1.1"
-    implementation 'com.android.volley:volley:1.1.1'
+    implementation 'com.android.volley:volley:1.2.1'
 }

--- a/react-native-fcm.podspec
+++ b/react-native-fcm.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.requires_arc  = true
   s.homepage      = "https://github.com/evollu/react-native-fcm"
   s.source        = { :git => 'https://github.com/evollu/react-native-fcm.git' }
-  s.platform      = :ios, '10.0'
+  s.platform      = :ios, '11.0'
   s.source_files  = "ios/*.{h,m}"
   s.public_header_files = ['ios/RNFIRMessaging.h']
   s.static_framework = true


### PR DESCRIPTION
Upgraded the `volley` version to `1.2.1` to fix an error with `react-native-fcm` in the android build of `petalmd.mobile` after the update of react native 64 to 66.

Source: https://developer.android.com/training/volley/index.html#groovy